### PR TITLE
Validate IP entry before saving to settings file on every edit.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ rpyc==6.0.0
 serpent==1.41
 streamcontroller-plugin-tools>=2.0.0
 websocket-client==1.7.0
+fipv==1.0.0


### PR DESCRIPTION
  Discard invalid addresses rather than try to connect to them.  It should not be possible for the plugin to save an invalid address now.  I do feel that we should not call this function on every single character typed in to the entry field, however.  This might be the wrong approach but it prevents an issue I was having with the application hanging when an invalid IP is entered (just enter the number `1` in the current version).