### PR TITLE
'Toggle Streaming' is missing a letter.

### DIFF
--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -1,7 +1,7 @@
 {
     "plugin.name": "OBS",
 
-    "actions.toggle-stream.name": "Toggle Steaming",
+    "actions.toggle-stream.name": "Toggle Streaming",
 
     "actions.toggle-record.name": "Toggle Recording",
     "actions.rec-play-pause.name": "Play/Pause Recording",


### PR DESCRIPTION
The name of the 'Toggle Streaming' action is missing the letter 'r' and is spelt 'Toggle Steaming'.