### PR TITLE
Fix "Switch Scene" switching the Program Scene in Studio Mode (Issue #11)

### DIFF
--- a/backend/OBSController.py
+++ b/backend/OBSController.py
@@ -333,13 +333,20 @@ class OBSController(obsws):
             return [scene["sceneName"] for scene in scenes]
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
-    def switch_to_scene(self, scene:str) -> None:
-        try:
-            self.call(requests.SetCurrentProgramScene(sceneName=scene))
-        except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
-            log.error(e)
 
+    ## Credit for Studio Mode Preview fix: Rinma (https://github.com/Rinma)
+    def switch_to_scene(self, scene:str) -> None:
+        studioModeStatus = self.get_studio_mode_enabled()
+        if studioModeStatus.datain["studioModeEnabled"]:
+            try:
+                self.call(requests.SetCurrentPreviewScene(sceneName=scene))
+            except (obswebsocket.exceptions.MessageTimeout, websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
+                log.error(e)
+        else:
+            try:
+                self.call(requests.SetCurrentProgramScene(sceneName=scene))
+            except (obswebsocket.exceptions.MessageTimeout, websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
+                log.error(e)
     
     ## Scene Collections
     def get_scene_collections(self) -> list:


### PR DESCRIPTION
Using the "Switch Scene" action while OBS Studio Mode was enabled, would switch the Program Scene instead of the Preview Scene, which makes the "Trigger Transition" action useless.

This just implements the suggested fix by @Rinma (https://github.com/StreamController/OBSPlugin/issues/11#issuecomment-2393949173)

I made a pull request in spite of this being bug-fix only, since I do see this as a bug because of the clear intentions with the "Trigger Transition" action.