### PR TITLE
fix(backend)(#17): remove fipv dep

### DIFF
--- a/backend/OBSController.py
+++ b/backend/OBSController.py
@@ -20,7 +20,14 @@ class OBSController(obsws):
         # to do long-term.
 
         try:
-            _ = ipaddress.ip_address(host)
+            addr = ipaddress.ip_address(host)
+
+            # And we're disallowing IPv6 entries here, for compatibility with
+            # previous implementations. Again, probably the wrong thing
+            # long-term, but implementing this way to mitigate risk while we're
+            # in a bad-push state.
+            if not addr.version == ipaddress.IPv4Address.version:
+                raise ValueError()
             return True
         except ValueError:
             return False

--- a/backend/OBSController.py
+++ b/backend/OBSController.py
@@ -1,10 +1,9 @@
 from obswebsocket import obsws, requests
 import obswebsocket
-from loguru import logger as log 
+from loguru import logger as log
 import websocket
 import socket
 import ipaddress
-import fipv
 
 class OBSController(obsws):
     def __init__(self):
@@ -16,7 +15,15 @@ class OBSController(obsws):
         if host in ("localhost", "127.0.0.1"):
             return True
 
-        return fipv.ipv4(host)
+        # We're explicitly disallowing non-localhost DNS entries here.
+        # Continuing this pattern for now, but this is probably the wrong thing
+        # to do long-term.
+
+        try:
+            _ = ipaddress.ip_address(host)
+            return True
+        except ValueError:
+            return False
 
     def on_connect(self, obs):
         self.connected = True
@@ -43,7 +50,7 @@ class OBSController(obsws):
                 if self.event_obs.ws is not None:
                     self.event_obs.disconnect()
             return False
-        
+
         try:
             log.debug(f"Trying to connect to obs with legacy: {legacy}")
             super().__init__(host=host, port=port, timeout=timeout, legacy=legacy, on_connect=self.on_connect, on_disconnect=self.on_disconnect, authreconnect=5, **kwargs)
@@ -58,7 +65,7 @@ class OBSController(obsws):
                 self.event_obs = obsws(host=host, port=port, timeout=timeout, legacy=not legacy, on_connect=self.on_connect, on_disconnect=self.on_disconnect, authreconnect=5, **kwargs)
                 self.connect()
                 log.info("Successfully connected to OBS")
-            
+
             # ValueError: invalid port etc
             except (obswebsocket.exceptions.ConnectionFailure, ValueError) as e:
                 log.error(f"Failed to connect to OBS: {e}")
@@ -101,13 +108,13 @@ class OBSController(obsws):
             return self.call(requests.GetStreamStatus())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def send_stream_caption(self, caption:str):
         try:
             self.call(requests.SendStreamCaption(caption=caption))
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
 
     ## Recording
     def start_record(self) -> None:
@@ -115,13 +122,13 @@ class OBSController(obsws):
             return self.call(requests.StartRecord())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def pause_record(self):
         try:
             return self.call(requests.PauseRecord())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def resume_record(self):
         try:
             return self.call(requests.ResumeRecord())
@@ -136,7 +143,7 @@ class OBSController(obsws):
             return self.call(requests.StopRecord())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def get_record_status(self):
         """
         outputActive: bool -> Whether recording is active
@@ -149,20 +156,20 @@ class OBSController(obsws):
             return self.call(requests.GetRecordStatus())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def toggle_record(self):
         try:
             return self.call(requests.ToggleRecord())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def toggle_record_pause(self):
         try:
             return self.call(requests.ToggleRecordPause())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
-    
+
+
     ## Replay Buffer
     def get_replay_buffer_status(self):
         """
@@ -184,7 +191,7 @@ class OBSController(obsws):
             return self.call(requests.StartReplayBuffer())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def stop_replay_buffer(self):
         try:
             return self.call(requests.StopReplayBuffer())
@@ -219,7 +226,7 @@ class OBSController(obsws):
             return self.call(requests.StartVirtualCam())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def stop_virtual_camera(self):
         try:
             return self.call(requests.StopVirtualCam())
@@ -235,7 +242,7 @@ class OBSController(obsws):
             return self.call(requests.GetStudioModeEnabled())
         except (obswebsocket.exceptions.MessageTimeout,  websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
             log.error(e)
-    
+
     def set_studio_mode_enabled(self, enabled:bool):
         try:
             return self.call(requests.SetStudioModeEnabled(studioModeEnabled=enabled))
@@ -347,7 +354,7 @@ class OBSController(obsws):
                 self.call(requests.SetCurrentProgramScene(sceneName=scene))
             except (obswebsocket.exceptions.MessageTimeout, websocket._exceptions.WebSocketConnectionClosedException, KeyError) as e:
                 log.error(e)
-    
+
     ## Scene Collections
     def get_scene_collections(self) -> list:
         try:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,5 +3,4 @@ obs-websocket-py==1.0
 rpyc==6.0.0
 serpent==1.41
 streamcontroller-plugin-tools>=2.0.1
-fipv==1.0.0
 websocket-client==1.7.0


### PR DESCRIPTION
* Non-intrusive removal of `fipv` as an IP address validator in the backend.
  * (This function could almost certainly move to the frontend now that no library is required, but keeping this change as minimal as possible to mitigate risk.)

## Testing

* Manual IP entry in configuration pane in Flatpak env (in a clean app dir). IPv6 remains disallowed for now.
  * Invocation: `flatpak run --branch=stable --arch=x86_64 --command=/app/bin/launch.sh com.core447.StreamController --data /home/kekemui/.config/streamcontroller`