### PR TITLE
fix(state): fix instance of enum detection

### DIFF
--- a/actions/mixins/MixinBase.py
+++ b/actions/mixins/MixinBase.py
@@ -27,8 +27,8 @@ class MixinBase(ABC):
 
     @current_state.setter
     def current_state(self, val: int | State):
-        if not isinstance(val, State):
-            log.warning(f"current_state setter called with non-State type {type(val)}.")
+        if not val in State:
+            log.warning(f"current_state setter called with non-State type {type(val)=} {val=}.")
             val = State(val)
 
         self._current_state = val


### PR DESCRIPTION
* Addresses `isinstance` check somehow deciding that a passed in `State.UNKNOWN` was not an instance of `State`.
    * This failure was driving the spam logging when StreamController was not connected to OBS.

### Repro

1. Using current store version of OBSPlugin
2. Ensure StreamController is not currently connected to OBS. This is achieved if OBS is not running when StreamController starts.
3. Change to a page with a SetInputMute action
4. Observe that the log is spammed with `actions.mixins.MixinBase:current_state:31 - current_state setter called with non-State type <enum 'State'>.`.

### Testing

1. Added Kekemui/OBSPlugin/state-not-state-log as a custom plugin, disabled automatic update, and in the store updated to the custom version
2. Restarted (via `Quit`) StreamController
3. Following the steps above results in no log messages.

No other testing was performed.